### PR TITLE
remove street address from User model [Fixes: #115542107]

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,6 @@ class User < ActiveRecord::Base
   geocoded_by :address
   reverse_geocoded_by :latitude, :longitude, address: :location do |obj,results|
     if geo = results.first
-      obj.street   = geo.street_address
       obj.city     = geo.city
       obj.state    = geo.state
       obj.country  = geo.country
@@ -58,7 +57,7 @@ class User < ActiveRecord::Base
   private
   
   def address
-    [street, city, state, country].compact.join(', ')
+    [city, state, country].compact.join(', ')
   end
   
 end

--- a/db/migrate/20160315063140_remove_street_from_users.rb
+++ b/db/migrate/20160315063140_remove_street_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveStreetFromUsers < ActiveRecord::Migration
+  def change
+    remove_column :users, :street, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160314105402) do
+ActiveRecord::Schema.define(version: 20160315063140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,7 +86,6 @@ ActiveRecord::Schema.define(version: 20160314105402) do
     t.string   "uid"
     t.float    "latitude"
     t.float    "longitude"
-    t.string   "street"
     t.string   "city"
     t.string   "state"
     t.string   "country"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_db_column :email }
     it { is_expected.to have_db_column :longitude }
     it { is_expected.to have_db_column :latitude }
-    it { is_expected.to have_db_column :street }
     it { is_expected.to have_db_column :city }
     it { is_expected.to have_db_column :state }
     it { is_expected.to have_db_column :country }
@@ -143,7 +142,6 @@ RSpec.describe User, type: :model do
     let(:user) { FactoryGirl.create(:user, user_name: 'Zmago', latitude: 45.960491, longitude: 13.6599124 ) }
   
     it 'should set the address to user' do
-      expect(user.street).to eq '3 Damber'
       expect(user.city).to eq 'Kromberk'
       expect(user.state).to eq 'Nova Gorica'
       expect(user.country).to eq 'Slovenia'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/115542107

@tochman here I encounter a problem when I run rake db:migrate it deletes the:
-  create_table "authentication_tokens", force: :cascade do |t|
-    t.string   "body"
-    t.integer  "user_id"
-    t.datetime "last_used_at"
-    t.string   "ip_address"
-    t.string   "user_agent"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
## \-  end
## \-  add_index "authentication_tokens", ["user_id"], name: "index_authentication_tokens_on_user_id", using: :btree
-  create_table "identities", force: :cascade do |t|
-    t.integer  "user_id"
-    t.string   "provider"
-    t.string   "uid"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
## \-  end
-  add_index "identities", ["user_id"], name: "index_identities_on_user_id", using: :btree

from the schema are there some pending migration on the develop branch or something?
