### PR TITLE
113425157 Add gem phantomjs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'poltergeist'
+  gem 'phantomjs', :require => 'phantomjs/poltergeist'
   gem 'rack-test'
   gem 'vcr'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,7 @@ GEM
       omniauth (~> 1.2)
     orm_adapter (0.5.0)
     pg (0.18.4)
+    phantomjs (2.1.1.0)
     poltergeist (1.9.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -386,6 +387,7 @@ DEPENDENCIES
   omniauth
   omniauth-facebook
   pg
+  phantomjs
   poltergeist
   pry
   pry-byebug


### PR DESCRIPTION
Adding gem phantomjs, as poltergeist needs this to work correctly, if phantomjs is not locally installed. This particularly affects developers working in c9.io. 
